### PR TITLE
feat(core): add homepage template and enable Django templates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+DEBUG=True
+SECRET_KEY=
+ALLOWED_HOSTS=127.0.0.1,localhost

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# BeatNest
+
+Django 5 project bootstrapped on macOS.
+- App: `core`
+- Python: 3.13 (Homebrew)
+- Env: `.env` (not committed) via `django-environ`
+
+## Local dev
+```bash
+python manage.py runserver
+git add README.md
+git commit -m "docs: add project README"
+git push
+# prove .env is ignored (should print a line showing .gitignore matched it)
+git check-ignore -v .env
+
+# add a safe example env file
+cat > .env.example << 'EOF'
+DEBUG=True
+SECRET_KEY=
+ALLOWED_HOSTS=127.0.0.1,localhost

--- a/config/settings.py
+++ b/config/settings.py
@@ -45,7 +45,9 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
   
     # Third-party 'rest_framework',
+    
     # Local apps 'core',
+     'core.apps.CoreConfig',
 ]
 
 MIDDLEWARE = [

--- a/core/templates/core/home.html
+++ b/core/templates/core/home.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>BeatNest</title>
+    <style>
+      body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; 
+margin: 3rem; }
+      h1 { margin: 0 0 .5rem; }
+      .muted { color: #667085; }
+    </style>
+  </head>
+  <body>
+    <h1>BeatNest is live 🎶</h1>
+    <p class="muted">Find the Beat. Land the Gig.</p>
+  </body>
+</html>
+

--- a/core/views.py
+++ b/core/views.py
@@ -1,7 +1,6 @@
-from django.http import HttpResponse
+from django.shortcuts import render
 
 def home(request):
-    return HttpResponse("""<h1>BeatNest is live 🎶</h1><p>Find the Beat. Land the 
-Gig.</p>""")
+    return render(request, "core/home.html")
 
 


### PR DESCRIPTION
Summary

Create core/templates/core/home.html (simple styled landing page).

Switch core.views.home from HttpResponse to render("core/home.html").

Register app in INSTALLED_APPS using core.apps.CoreConfig (so app templates load).

Add README.md and .env.example to document local setup.

No models, migrations, or API changes.

Why

Move off raw string HTML and establish the standard Django template structure for future pages. Adds minimal project docs and a safe env example for onboarding.

Testing

From project root:

python manage.py runserver


Visit http://127.0.0.1:8000/ → see the styled “BeatNest is live 🎶” page.

Confirm template path exists:

ls -la core/templates/core/  # should list home.html


Sanity check settings:

python - <<'PY'


from django.conf import settings
print('core.apps.CoreConfig' in settings.INSTALLED_APPS)
PY

prints True

### Impact / Risk
- Low. View rendering and settings only; no DB or external side effects.

### Notes
- `.env` is **ignored** by `.gitignore`; `.env.example` shows required keys.
- Follow-ups: introduce `base.html`, wire static files, and add a simple layout.

That’s it—hit **Create pull request** with that.
