### PR TITLE
feat(core): add base layout and app.css; make home extend base

### DIFF
--- a/core/static/core/app.css
+++ b/core/static/core/app.css
@@ -1,0 +1,7 @@
+:root { color-scheme: light dark; }
+body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, 
+sans-serif; margin: 2rem; }
+.container { max-width: 900px; margin-inline: auto; }
+.muted { color: #666; }
+h1 { margin: 0 0 .75rem; }
+

--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -1,0 +1,18 @@
+{% load static %}
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{% block title %}BeatNest{% endblock %}</title>
+    <link rel="stylesheet" href="{% static 'core/app.css' %}">
+    {% block head_extra %}{% endblock %}
+  </head>
+  <body>
+    <main class="container">
+      {% block content %}{% endblock %}
+    </main>
+    {% block scripts %}{% endblock %}
+  </body>
+</html>
+

--- a/core/templates/core/home.html
+++ b/core/templates/core/home.html
@@ -1,19 +1,8 @@
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>BeatNest</title>
-    <style>
-      body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; 
-margin: 3rem; }
-      h1 { margin: 0 0 .5rem; }
-      .muted { color: #667085; }
-    </style>
-  </head>
-  <body>
-    <h1>BeatNest is live 🎶</h1>
-    <p class="muted">Find the Beat. Land the Gig.</p>
-  </body>
-</html>
+{% extends "base.html" %}
+{% block title %}BeatNest{% endblock %}
+
+{% block content %}
+  <h1>BeatNest is live 🎶</h1>
+  <p class="muted">Find the Beat. Land the Gig.</p>
+{% endblock %}
 


### PR DESCRIPTION
Summary
- Create `core/templates/base.html` with blocks: `title`, `head_extra`, `content`, `scripts`.
- Add `core/static/core/app.css` (light theme, typography, container).
- Update `core/templates/core/home.html` to `{% extends "base.html" %}` and use blocks.
- Link stylesheet via `{% load static %}` + `{% static 'core/app.css' %}`.

Why
- Establishes a reusable layout so future pages share structure/styles.
- Moves styles out of inline HTML and into a single static file.

Notes / Impact
- No models, migrations, or settings changes.
- Low risk; affects template rendering only.

Test
1) `python manage.py runserver`
2) Visit `http://127.0.0.1:8000/`
3) Page renders with styled layout; page source includes `/static/core/app.css`.
